### PR TITLE
Use __FILE as marker for file replacement to avoid issues with variables ending in _FILE

### DIFF
--- a/5/debian9/5.4/docker-entrypoint.sh
+++ b/5/debian9/5.4/docker-entrypoint.sh
@@ -60,11 +60,11 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
-# Convert all environment variables with names ending in _FILE into the content of
-# the file that they point at and use the name without the trailing _FILE.
+# Convert all environment variables with names ending in __FILE into the content of
+# the file that they point at and use the name without the trailing __FILE.
 # This can be used to carry in Docker secrets.
-for VAR_NAME in $(env | grep '^GF_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
-    VAR_NAME_FILE="$VAR_NAME"_FILE
+for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"__FILE
     if [ "${!VAR_NAME}" ]; then
         echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
         exit 1

--- a/5/debian9/5.4/docker-entrypoint.sh
+++ b/5/debian9/5.4/docker-entrypoint.sh
@@ -60,11 +60,11 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
-# Convert all environment variables with names ending in __FILE into the content of
-# the file that they point at and use the name without the trailing __FILE.
+# Convert all environment variables with names ending in _FILE into the content of
+# the file that they point at and use the name without the trailing _FILE.
 # This can be used to carry in Docker secrets.
-for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
-    VAR_NAME_FILE="$VAR_NAME"__FILE
+for VAR_NAME in $(env | grep '^GF_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"_FILE
     if [ "${!VAR_NAME}" ]; then
         echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
         exit 1

--- a/6/debian9/6.7/docker-entrypoint.sh
+++ b/6/debian9/6.7/docker-entrypoint.sh
@@ -60,11 +60,11 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
-# Convert all environment variables with names ending in _FILE into the content of
-# the file that they point at and use the name without the trailing _FILE.
+# Convert all environment variables with names ending in __FILE into the content of
+# the file that they point at and use the name without the trailing __FILE.
 # This can be used to carry in Docker secrets.
-for VAR_NAME in $(env | grep '^GF_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
-    VAR_NAME_FILE="$VAR_NAME"_FILE
+for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"__FILE
     if [ "${!VAR_NAME}" ]; then
         echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
         exit 1

--- a/6/debian9/6.7/docker-entrypoint.sh
+++ b/6/debian9/6.7/docker-entrypoint.sh
@@ -60,11 +60,11 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
-# Convert all environment variables with names ending in __FILE into the content of
-# the file that they point at and use the name without the trailing __FILE.
+# Convert all environment variables with names ending in _FILE into the content of
+# the file that they point at and use the name without the trailing _FILE.
 # This can be used to carry in Docker secrets.
-for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
-    VAR_NAME_FILE="$VAR_NAME"__FILE
+for VAR_NAME in $(env | grep '^GF_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"_FILE
     if [ "${!VAR_NAME}" ]; then
         echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
         exit 1

--- a/7/debian9/7.3/docker-entrypoint.sh
+++ b/7/debian9/7.3/docker-entrypoint.sh
@@ -60,11 +60,11 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
-# Convert all environment variables with names ending in _FILE into the content of
-# the file that they point at and use the name without the trailing _FILE.
+# Convert all environment variables with names ending in __FILE into the content of
+# the file that they point at and use the name without the trailing __FILE.
 # This can be used to carry in Docker secrets.
-for VAR_NAME in $(env | grep '^GF_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
-    VAR_NAME_FILE="$VAR_NAME"_FILE
+for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"__FILE
     if [ "${!VAR_NAME}" ]; then
         echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
         exit 1

--- a/7/debian9/7.3/docker-entrypoint.sh
+++ b/7/debian9/7.3/docker-entrypoint.sh
@@ -60,11 +60,11 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
-# Convert all environment variables with names ending in __FILE into the content of
-# the file that they point at and use the name without the trailing __FILE.
+# Convert all environment variables with names ending in _FILE into the content of
+# the file that they point at and use the name without the trailing _FILE.
 # This can be used to carry in Docker secrets.
-for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
-    VAR_NAME_FILE="$VAR_NAME"__FILE
+for VAR_NAME in $(env | grep '^GF_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"_FILE
     if [ "${!VAR_NAME}" ]; then
         echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
         exit 1

--- a/7/debian9/7.4/docker-entrypoint.sh
+++ b/7/debian9/7.4/docker-entrypoint.sh
@@ -60,11 +60,11 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
-# Convert all environment variables with names ending in _FILE into the content of
-# the file that they point at and use the name without the trailing _FILE.
+# Convert all environment variables with names ending in __FILE into the content of
+# the file that they point at and use the name without the trailing __FILE.
 # This can be used to carry in Docker secrets.
-for VAR_NAME in $(env | grep '^GF_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
-    VAR_NAME_FILE="$VAR_NAME"_FILE
+for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"__FILE
     if [ "${!VAR_NAME}" ]; then
         echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
         exit 1

--- a/7/debian9/7.4/docker-entrypoint.sh
+++ b/7/debian9/7.4/docker-entrypoint.sh
@@ -60,11 +60,11 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
-# Convert all environment variables with names ending in __FILE into the content of
-# the file that they point at and use the name without the trailing __FILE.
+# Convert all environment variables with names ending in _FILE into the content of
+# the file that they point at and use the name without the trailing _FILE.
 # This can be used to carry in Docker secrets.
-for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
-    VAR_NAME_FILE="$VAR_NAME"__FILE
+for VAR_NAME in $(env | grep '^GF_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"_FILE
     if [ "${!VAR_NAME}" ]; then
         echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
         exit 1

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -60,11 +60,11 @@ if [ ! -z ${GF_AWS_PROFILES+x} ]; then
     chmod 600 "$GF_PATHS_HOME/.aws/credentials"
 fi
 
-# Convert all environment variables with names ending in _FILE into the content of
-# the file that they point at and use the name without the trailing _FILE.
+# Convert all environment variables with names ending in __FILE into the content of
+# the file that they point at and use the name without the trailing __FILE.
 # This can be used to carry in Docker secrets.
-for VAR_NAME in $(env | grep '^GF_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
-    VAR_NAME_FILE="$VAR_NAME"_FILE
+for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"__FILE
     if [ "${!VAR_NAME}" ]; then
         echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
         exit 1


### PR DESCRIPTION
Unable to configure HTTPS using ENV overrides due to GF_SERVER_CERT_FILE being picked up as a secret via this code. This change matches one made to the Grafana upstream in 2018.

Fixes #45 